### PR TITLE
Remove judge titles from list

### DIFF
--- a/lil_nocap/nocap.py
+++ b/lil_nocap/nocap.py
@@ -5,6 +5,7 @@ import time
 import timeit
 import os
 import click
+import re
 
 class NoCap:
   def __init__(self, opinions_fn, opinion_clusters_fn, courts_fn, dockets_fn, citation_fn):
@@ -209,6 +210,12 @@ class NoCap:
 
     #judges
     judges = cluster_row.judges
+    judge_list = [
+        judge
+        for judge in
+            (judges.iloc[0].split(',') if judges.notna().bool() else [])
+        if not re.match('[cj]?j\.', judge)
+    ]
         
     obj = {
         'id': cluster_id,
@@ -222,7 +229,7 @@ class NoCap:
         'court' : {'name': court_row.full_name.iloc[0]},
         'jurisdiction' : {'name': court_row.jurisdiction.iloc[0]},
         'casebody' : {'data': {
-            'judges': judges.iloc[0].split(',') if judges.notna().bool() else [],
+            'judges': judge_list,
             'head_matter':'', #Ask CL about copyright,
             'opinions': [{
                 'text': self.get_opinion_text(opinion), 
@@ -274,5 +281,3 @@ class NoCap:
 
 if __name__ == '__main__':
   NoCap.cli()
-   
-


### PR DESCRIPTION
Lists of judges are comma-separated, but some include comma-separated titles as well, e.g.: `"Roberts, CJ."`. Previously, `"CJ"` was entered as a judge for the cluster. This small PR adds a filter to remove these spurious 'judges'. An ideal fix would use a smarter regex split to include the judge's title in their name entry, and perhaps accommodate more kinds of titles and judge lists. This change is more of a quick fix for a minor issue.